### PR TITLE
build: s/-Ofast/-O3 -ffast-math/

### DIFF
--- a/cmake/Toolchain-gcc-clang.cmake
+++ b/cmake/Toolchain-gcc-clang.cmake
@@ -50,7 +50,7 @@ endif()
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_options(-ggdb3 -fno-omit-frame-pointer -Wall -Wextra)
 else()
-    add_compile_options(-Ofast -fomit-frame-pointer)
+    add_compile_options(-O3 -ffast-math -fomit-frame-pointer)
 endif()
 
 # for some reason this is necessary

--- a/src/libretro/Makefile
+++ b/src/libretro/Makefile
@@ -79,7 +79,7 @@ else ifeq ($(platform), classic_armv7_a7)
 	TARGET := $(TARGET_NAME)_libretro.so
 	fpic := -fPIC
 	SHARED := -shared -Wl,--no-undefined -fPIC
-	CFLAGS += -Ofast \
+	CFLAGS += -O3 -ffast-math \
 	-flto=4 -fwhole-program -fuse-linker-plugin \
 	-fdata-sections -ffunction-sections -Wl,--gc-sections \
 	-fno-stack-protector -fno-ident -fomit-frame-pointer \
@@ -112,7 +112,7 @@ else ifeq ($(platform), classic_armv8_a35)
 	fpic := -fPIC
 	SHARED := -shared
 	TILED_RENDERING=1
-	CFLAGS += -Ofast \
+	CFLAGS += -O3 -ffast-math \
 	-flto=4 -fwhole-program -fuse-linker-plugin \
 	-fdata-sections -ffunction-sections -Wl,--gc-sections \
 	-fno-stack-protector -fno-ident -fomit-frame-pointer \


### PR DESCRIPTION
Use `-O3 -ffast-math` instead of `-Ofast`, which is deprecated by the latest clang. In both our options and for libretro.